### PR TITLE
Pull out compression into its own class

### DIFF
--- a/Source/RuntimeAudioImporter/Private/RuntimeAudioCompressor.cpp
+++ b/Source/RuntimeAudioImporter/Private/RuntimeAudioCompressor.cpp
@@ -1,0 +1,211 @@
+// Georgy Treshchev 2022.
+
+#include "RuntimeAudioCompressor.h"
+
+#include "RuntimeAudioImporterDefines.h"
+#include "RuntimeAudioImporterTypes.h"
+
+#include "Transcoders/RAWTranscoder.h"
+#include "Transcoders/VorbisTranscoder.h"
+#include "Transcoders/WAVTranscoder.h"
+
+#include "Async/Async.h"
+
+#if ENGINE_MAJOR_VERSION < 5
+#include "AudioDevice.h"
+#include "AudioCompressionSettingsUtils.h"
+#endif
+
+URuntimeAudioCompressor* URuntimeAudioCompressor::Create()
+{
+	return NewObject<URuntimeAudioCompressor>();
+}
+
+void URuntimeAudioCompressor::CompressSoundWave(UImportedSoundWave* ImportedSoundWaveRef, FCompressedSoundWaveInfo CompressedSoundWaveInfo, uint8 Quality, bool bFillCompressedBuffer, bool bFillPCMBuffer, bool bFillRAWWaveBuffer)
+{
+	USoundWave* RegularSoundWaveRef = NewObject<USoundWave>(USoundWave::StaticClass());
+
+	if (!RegularSoundWaveRef)
+	{
+		BroadcastResult(nullptr);
+		return;
+	}
+
+	RegularSoundWaveRef->AddToRoot();
+
+	AsyncTask(ENamedThreads::AnyBackgroundHiPriTask, [this,ImportedSoundWaveRef, RegularSoundWaveRef, Quality, bFillPCMBuffer, bFillRAWWaveBuffer, bFillCompressedBuffer, CompressedSoundWaveInfo]()
+	{
+		// Filling in decoded audio info
+		FDecodedAudioStruct DecodedAudioInfo;
+		{
+			DecodedAudioInfo.PCMInfo = ImportedSoundWaveRef->PCMBufferInfo;
+			FSoundWaveBasicStruct SoundWaveBasicInfo;
+			{
+				SoundWaveBasicInfo.NumOfChannels = ImportedSoundWaveRef->NumChannels;
+				SoundWaveBasicInfo.SampleRate = ImportedSoundWaveRef->SamplingRate;
+				SoundWaveBasicInfo.Duration = ImportedSoundWaveRef->Duration;
+			}
+			DecodedAudioInfo.SoundWaveBasicInfo = SoundWaveBasicInfo;
+		}
+
+		// Filling in the basic information of the sound wave
+		{
+			RegularSoundWaveRef->Duration = DecodedAudioInfo.SoundWaveBasicInfo.Duration;
+			RegularSoundWaveRef->SetSampleRate(DecodedAudioInfo.SoundWaveBasicInfo.SampleRate);
+			RegularSoundWaveRef->NumChannels = DecodedAudioInfo.SoundWaveBasicInfo.NumOfChannels;
+			RegularSoundWaveRef->SoundGroup = SOUNDGROUP_Default;
+
+			if (RegularSoundWaveRef->NumChannels == 4)
+			{
+				RegularSoundWaveRef->bIsAmbisonics = 1;
+			}
+
+			RegularSoundWaveRef->bProcedural = false;
+			RegularSoundWaveRef->DecompressionType = EDecompressionType::DTYPE_RealTime;
+
+			// Filling in the compressed sound wave info
+			{
+				RegularSoundWaveRef->SoundGroup = CompressedSoundWaveInfo.SoundGroup;
+				RegularSoundWaveRef->bLooping = CompressedSoundWaveInfo.bLooping;
+				RegularSoundWaveRef->Volume = CompressedSoundWaveInfo.Volume;
+				RegularSoundWaveRef->Pitch = CompressedSoundWaveInfo.Pitch;
+			}
+		}
+
+		// Filling in the standard PCM buffer if needed
+		if (bFillPCMBuffer)
+		{
+			int16* RawPCMData;
+			int32 RawPCMDataSize;
+			RAWTranscoder::TranscodeRAWData<float, int16>(reinterpret_cast<float*>(DecodedAudioInfo.PCMInfo.PCMData.GetView().GetData()), DecodedAudioInfo.PCMInfo.PCMData.GetView().Num(), RawPCMData, RawPCMDataSize);
+			RegularSoundWaveRef->RawPCMDataSize = RawPCMDataSize;
+			RegularSoundWaveRef->RawPCMData = static_cast<uint8*>(FMemory::Malloc(RawPCMDataSize));
+			FMemory::Memcpy(RegularSoundWaveRef->RawPCMData, RawPCMData, RawPCMDataSize);
+
+			FMemory::Free(RawPCMData);
+
+			RegularSoundWaveRef->SetPrecacheState(ESoundWavePrecacheState::Done);
+
+			UE_LOG(LogRuntimeAudioImporter, Log, TEXT("Filled PCM Buffer with size '%d'"), RawPCMDataSize);
+		}
+
+		// Filling in the standard RAW Wave 16-bit buffer if needed
+		if (bFillRAWWaveBuffer)
+		{
+			int16* RawPCMData;
+			int32 RawPCMDataSize;
+			RAWTranscoder::TranscodeRAWData<float, int16>(reinterpret_cast<float*>(DecodedAudioInfo.PCMInfo.PCMData.GetView().GetData()), DecodedAudioInfo.PCMInfo.PCMData.GetView().Num(), RawPCMData, RawPCMDataSize);
+
+			FDecodedAudioStruct CustomDecodedAudioInfo;
+			{
+				CustomDecodedAudioInfo.SoundWaveBasicInfo = DecodedAudioInfo.SoundWaveBasicInfo;
+				CustomDecodedAudioInfo.PCMInfo.PCMData = FBulkDataBuffer<uint8>(reinterpret_cast<uint8*>(RawPCMData), RawPCMDataSize);
+				CustomDecodedAudioInfo.PCMInfo.PCMNumOfFrames = DecodedAudioInfo.PCMInfo.PCMNumOfFrames;
+			}
+
+			// Encoding to WAV format
+			FEncodedAudioStruct EncodedAudioInfo;
+			if (!WAVTranscoder::Encode(CustomDecodedAudioInfo, EncodedAudioInfo, FWAVEncodingFormat(EWAVEncodingFormat::FORMAT_PCM, 16)))
+			{
+				UE_LOG(LogRuntimeAudioImporter, Error, TEXT("Unable to encode PCM to WAV format due to transcoder error"));
+				BroadcastResult(nullptr);
+				return;
+			}
+
+			RegularSoundWaveRef->RawData.Lock(LOCK_READ_WRITE);
+			FMemory::Memcpy(RegularSoundWaveRef->RawData.Realloc(EncodedAudioInfo.AudioData.GetView().Num()), EncodedAudioInfo.AudioData.GetView().GetData(), EncodedAudioInfo.AudioData.GetView().Num());
+			RegularSoundWaveRef->RawData.Unlock();
+
+			RegularSoundWaveRef->SetPrecacheState(ESoundWavePrecacheState::Done);
+
+			UE_LOG(LogRuntimeAudioImporter, Log, TEXT("Filled RAW Wave Buffer with size '%d'"), EncodedAudioInfo.AudioData.GetView().Num());
+		}
+
+		// Filling in the compressed OGG buffer
+		if (bFillCompressedBuffer)
+		{
+			FEncodedAudioStruct EncodedAudioInfo;
+			if (!VorbisTranscoder::Encode(DecodedAudioInfo, EncodedAudioInfo, Quality))
+			{
+				UE_LOG(LogRuntimeAudioImporter, Error, TEXT("Something went wrong while encoding Vorbis audio data"));
+			}
+
+			if (EncodedAudioInfo.AudioData.GetView().Num() <= 0)
+			{
+				BroadcastResult(nullptr);
+				return;
+			}
+
+			RegularSoundWaveRef->SetPrecacheState(ESoundWavePrecacheState::NotStarted);
+			RegularSoundWaveRef->SetPrecacheState(ESoundWavePrecacheState::InProgress);
+
+			{
+#if ENGINE_MAJOR_VERSION < 5
+
+				static const FName NAME_OGG{TEXT("OGG")};
+
+				// Getting the name of the current compressed platform-specific audio format
+				const FName CurrentAudioPlatformSpecificFormat{GetPlatformSpecificFormat(NAME_OGG)};
+
+				// Getting the compressed bulk data
+				FByteBulkData* CompressedBulkDataPtr = &RegularSoundWaveRef->CompressedFormatData.GetFormat(CurrentAudioPlatformSpecificFormat);
+
+#else
+				
+				FByteBulkData CompressedBulkData;
+				FByteBulkData* CompressedBulkDataPtr = &CompressedBulkData;
+
+#endif
+
+
+				// Filling in the compressed data
+				{
+					CompressedBulkDataPtr->Lock(LOCK_READ_WRITE);
+					FMemory::Memcpy(CompressedBulkDataPtr->Realloc(EncodedAudioInfo.AudioData.GetView().Num()), EncodedAudioInfo.AudioData.GetView().GetData(), EncodedAudioInfo.AudioData.GetView().Num());
+					CompressedBulkDataPtr->Unlock();
+				}
+
+#if ENGINE_MAJOR_VERSION >= 5
+				RegularSoundWaveRef->InitAudioResource(*CompressedBulkDataPtr);
+#endif
+			}
+
+			RegularSoundWaveRef->SetPrecacheState(ESoundWavePrecacheState::Done);
+
+			UE_LOG(LogRuntimeAudioImporter, Log, TEXT("Filled in the compressed audio buffer 'OGG' with size '%d'"), EncodedAudioInfo.AudioData.GetView().Num());
+		}
+
+		BroadcastResult(RegularSoundWaveRef);
+	});
+}
+
+void URuntimeAudioCompressor::BroadcastResult(USoundWave* SoundWaveRef)
+{
+	AsyncTask(ENamedThreads::GameThread, [this, SoundWaveRef]()
+	{
+		bool bBroadcasted = false;
+		const bool bSuccess = SoundWaveRef != nullptr;
+		
+		if( OnResultNative.IsBound() )
+		{
+			bBroadcasted = true;
+			OnResultNative.Broadcast( bSuccess, SoundWaveRef);
+		}
+		
+		if( OnResult.IsBound() )
+		{
+			bBroadcasted = true;
+			OnResult.Broadcast( bSuccess, SoundWaveRef );
+		}
+		
+		if( !SoundWaveRef )
+		{
+			SoundWaveRef->RemoveFromRoot();
+		}
+		
+		if( !bBroadcasted )
+		{
+			UE_LOG(LogRuntimeAudioImporter, Error, TEXT("You did not bind to the delegate to get the result of the import"));
+		}
+	});
+}

--- a/Source/RuntimeAudioImporter/Private/RuntimeAudioImporterLibrary.cpp
+++ b/Source/RuntimeAudioImporter/Private/RuntimeAudioImporterLibrary.cpp
@@ -183,177 +183,6 @@ FName GetPlatformSpecificFormat(const FName& Format)
 }
 #endif
 
-void URuntimeAudioImporterLibrary::CompressSoundWave(UImportedSoundWave* ImportedSoundWaveRef, FOnSoundWaveCompressedResult OnCompressedResult, FCompressedSoundWaveInfo CompressedSoundWaveInfo, uint8 Quality, bool bFillCompressedBuffer, bool bFillPCMBuffer, bool bFillRAWWaveBuffer)
-{
-	USoundWave* RegularSoundWaveRef = NewObject<USoundWave>(USoundWave::StaticClass());
-
-	if (RegularSoundWaveRef == nullptr)
-	{
-		OnCompressedResult.Execute(false, nullptr);
-		return;
-	}
-
-	RegularSoundWaveRef->AddToRoot();
-
-	AsyncTask(ENamedThreads::AnyBackgroundHiPriTask, [ImportedSoundWaveRef, RegularSoundWaveRef, Quality, bFillPCMBuffer, bFillRAWWaveBuffer, bFillCompressedBuffer, CompressedSoundWaveInfo, OnCompressedResult]()
-	{
-		// Filling in decoded audio info
-		FDecodedAudioStruct DecodedAudioInfo;
-		{
-			DecodedAudioInfo.PCMInfo = ImportedSoundWaveRef->PCMBufferInfo;
-			FSoundWaveBasicStruct SoundWaveBasicInfo;
-			{
-				SoundWaveBasicInfo.NumOfChannels = ImportedSoundWaveRef->NumChannels;
-				SoundWaveBasicInfo.SampleRate = ImportedSoundWaveRef->SamplingRate;
-				SoundWaveBasicInfo.Duration = ImportedSoundWaveRef->Duration;
-			}
-			DecodedAudioInfo.SoundWaveBasicInfo = SoundWaveBasicInfo;
-		}
-
-		// Filling in the basic information of the sound wave
-		{
-			RegularSoundWaveRef->Duration = DecodedAudioInfo.SoundWaveBasicInfo.Duration;
-			RegularSoundWaveRef->SetSampleRate(DecodedAudioInfo.SoundWaveBasicInfo.SampleRate);
-			RegularSoundWaveRef->NumChannels = DecodedAudioInfo.SoundWaveBasicInfo.NumOfChannels;
-			RegularSoundWaveRef->SoundGroup = SOUNDGROUP_Default;
-
-			if (RegularSoundWaveRef->NumChannels == 4)
-			{
-				RegularSoundWaveRef->bIsAmbisonics = 1;
-			}
-
-			RegularSoundWaveRef->bProcedural = false;
-			RegularSoundWaveRef->DecompressionType = EDecompressionType::DTYPE_RealTime;
-
-			// Filling in the compressed sound wave info
-			{
-				RegularSoundWaveRef->SoundGroup = CompressedSoundWaveInfo.SoundGroup;
-				RegularSoundWaveRef->bLooping = CompressedSoundWaveInfo.bLooping;
-				RegularSoundWaveRef->Volume = CompressedSoundWaveInfo.Volume;
-				RegularSoundWaveRef->Pitch = CompressedSoundWaveInfo.Pitch;
-			}
-		}
-
-		auto OnResultExecute = [OnCompressedResult](bool bSuccess, USoundWave* SoundWaveRef)
-		{
-			AsyncTask(ENamedThreads::GameThread, [bSuccess, OnCompressedResult, SoundWaveRef]()
-			{
-				OnCompressedResult.Execute(bSuccess, SoundWaveRef);
-
-				if (SoundWaveRef != nullptr)
-				{
-					SoundWaveRef->RemoveFromRoot();
-				}
-			});
-		};
-
-		// Filling in the standard PCM buffer if needed
-		if (bFillPCMBuffer)
-		{
-			int16* RawPCMData;
-			int32 RawPCMDataSize;
-			RAWTranscoder::TranscodeRAWData<float, int16>(reinterpret_cast<float*>(DecodedAudioInfo.PCMInfo.PCMData.GetView().GetData()), DecodedAudioInfo.PCMInfo.PCMData.GetView().Num(), RawPCMData, RawPCMDataSize);
-			RegularSoundWaveRef->RawPCMDataSize = RawPCMDataSize;
-			RegularSoundWaveRef->RawPCMData = static_cast<uint8*>(FMemory::Malloc(RawPCMDataSize));
-			FMemory::Memcpy(RegularSoundWaveRef->RawPCMData, RawPCMData, RawPCMDataSize);
-
-			FMemory::Free(RawPCMData);
-
-			RegularSoundWaveRef->SetPrecacheState(ESoundWavePrecacheState::Done);
-
-			UE_LOG(LogRuntimeAudioImporter, Log, TEXT("Filled PCM Buffer with size '%d'"), RawPCMDataSize);
-		}
-
-		// Filling in the standard RAW Wave 16-bit buffer if needed
-		if (bFillRAWWaveBuffer)
-		{
-			int16* RawPCMData;
-			int32 RawPCMDataSize;
-			RAWTranscoder::TranscodeRAWData<float, int16>(reinterpret_cast<float*>(DecodedAudioInfo.PCMInfo.PCMData.GetView().GetData()), DecodedAudioInfo.PCMInfo.PCMData.GetView().Num(), RawPCMData, RawPCMDataSize);
-
-			FDecodedAudioStruct CustomDecodedAudioInfo;
-			{
-				CustomDecodedAudioInfo.SoundWaveBasicInfo = DecodedAudioInfo.SoundWaveBasicInfo;
-				CustomDecodedAudioInfo.PCMInfo.PCMData = FBulkDataBuffer<uint8>(reinterpret_cast<uint8*>(RawPCMData), RawPCMDataSize);
-				CustomDecodedAudioInfo.PCMInfo.PCMNumOfFrames = DecodedAudioInfo.PCMInfo.PCMNumOfFrames;
-			}
-
-			// Encoding to WAV format
-			FEncodedAudioStruct EncodedAudioInfo;
-			if (!WAVTranscoder::Encode(CustomDecodedAudioInfo, EncodedAudioInfo, FWAVEncodingFormat(EWAVEncodingFormat::FORMAT_PCM, 16)))
-			{
-				UE_LOG(LogRuntimeAudioImporter, Error, TEXT("Unable to encode PCM to WAV format due to transcoder error"));
-				OnResultExecute(false, nullptr);
-				return;
-			}
-
-			RegularSoundWaveRef->RawData.Lock(LOCK_READ_WRITE);
-			FMemory::Memcpy(RegularSoundWaveRef->RawData.Realloc(EncodedAudioInfo.AudioData.GetView().Num()), EncodedAudioInfo.AudioData.GetView().GetData(), EncodedAudioInfo.AudioData.GetView().Num());
-			RegularSoundWaveRef->RawData.Unlock();
-
-			RegularSoundWaveRef->SetPrecacheState(ESoundWavePrecacheState::Done);
-
-			UE_LOG(LogRuntimeAudioImporter, Log, TEXT("Filled RAW Wave Buffer with size '%d'"), EncodedAudioInfo.AudioData.GetView().Num());
-		}
-
-		// Filling in the compressed OGG buffer
-		if (bFillCompressedBuffer)
-		{
-			FEncodedAudioStruct EncodedAudioInfo;
-			if (!VorbisTranscoder::Encode(DecodedAudioInfo, EncodedAudioInfo, Quality))
-			{
-				UE_LOG(LogRuntimeAudioImporter, Error, TEXT("Something went wrong while encoding Vorbis audio data"));
-			}
-
-			if (EncodedAudioInfo.AudioData.GetView().Num() <= 0)
-			{
-				OnResultExecute(false, nullptr);
-				return;
-			}
-
-			RegularSoundWaveRef->SetPrecacheState(ESoundWavePrecacheState::NotStarted);
-			RegularSoundWaveRef->SetPrecacheState(ESoundWavePrecacheState::InProgress);
-
-			{
-#if ENGINE_MAJOR_VERSION < 5
-
-				static const FName NAME_OGG{TEXT("OGG")};
-
-				// Getting the name of the current compressed platform-specific audio format
-				const FName CurrentAudioPlatformSpecificFormat{GetPlatformSpecificFormat(NAME_OGG)};
-
-				// Getting the compressed bulk data
-				FByteBulkData* CompressedBulkDataPtr = &RegularSoundWaveRef->CompressedFormatData.GetFormat(CurrentAudioPlatformSpecificFormat);
-
-#else
-				
-				FByteBulkData CompressedBulkData;
-				FByteBulkData* CompressedBulkDataPtr = &CompressedBulkData;
-
-#endif
-
-
-				// Filling in the compressed data
-				{
-					CompressedBulkDataPtr->Lock(LOCK_READ_WRITE);
-					FMemory::Memcpy(CompressedBulkDataPtr->Realloc(EncodedAudioInfo.AudioData.GetView().Num()), EncodedAudioInfo.AudioData.GetView().GetData(), EncodedAudioInfo.AudioData.GetView().Num());
-					CompressedBulkDataPtr->Unlock();
-				}
-
-#if ENGINE_MAJOR_VERSION >= 5
-				RegularSoundWaveRef->InitAudioResource(*CompressedBulkDataPtr);
-#endif
-			}
-
-			RegularSoundWaveRef->SetPrecacheState(ESoundWavePrecacheState::Done);
-
-			UE_LOG(LogRuntimeAudioImporter, Log, TEXT("Filled in the compressed audio buffer 'OGG' with size '%d'"), EncodedAudioInfo.AudioData.GetView().Num());
-		}
-
-		OnResultExecute(true, RegularSoundWaveRef);
-	});
-}
-
 void URuntimeAudioImporterLibrary::ImportAudioFromPreImportedSound(UPreImportedSoundAsset* PreImportedSoundAssetRef)
 {
 	ImportAudioFromBuffer(PreImportedSoundAssetRef->AudioDataArray, PreImportedSoundAssetRef->AudioFormat);
@@ -545,15 +374,14 @@ void URuntimeAudioImporterLibrary::ImportAudioFromDecodedInfo(const FDecodedAudi
 		return;
 	}
 
-	if (DefineSoundWave(SoundWaveRef, DecodedAudioInfo))
-	{
-		UE_LOG(LogRuntimeAudioImporter, Log, TEXT("The audio data was successfully imported. Information about imported data:\n%s"), *DecodedAudioInfo.ToString());
-		OnProgress_Internal(100);
-		OnResult_Internal(SoundWaveRef, ETranscodingStatus::SuccessfulImport);
-	}
+	DefineSoundWave(SoundWaveRef, DecodedAudioInfo);
+
+	UE_LOG(LogRuntimeAudioImporter, Log, TEXT("The audio data was successfully imported. Information about imported data:\n%s"), *DecodedAudioInfo.ToString());
+	OnProgress_Internal(100);
+	OnResult_Internal(SoundWaveRef, ETranscodingStatus::SuccessfulImport);
 }
 
-bool URuntimeAudioImporterLibrary::DefineSoundWave(UImportedSoundWave* SoundWaveRef, const FDecodedAudioStruct& DecodedAudioInfo)
+void URuntimeAudioImporterLibrary::DefineSoundWave(UImportedSoundWave* SoundWaveRef, const FDecodedAudioStruct& DecodedAudioInfo)
 {
 	OnProgress_Internal(70);
 
@@ -566,8 +394,6 @@ bool URuntimeAudioImporterLibrary::DefineSoundWave(UImportedSoundWave* SoundWave
 	FillPCMData(SoundWaveRef, DecodedAudioInfo);
 
 	OnProgress_Internal(95);
-
-	return true;
 }
 
 void URuntimeAudioImporterLibrary::FillSoundWaveBasicInfo(UImportedSoundWave* SoundWaveRef, const FDecodedAudioStruct& DecodedAudioInfo)
@@ -806,6 +632,11 @@ void URuntimeAudioImporterLibrary::OnProgress_Internal(int32 Percentage)
 		{
 			OnProgress.Broadcast(Percentage);
 		}
+		
+		if( OnProgressNative.IsBound() )
+		{
+			OnProgressNative.Broadcast(Percentage);
+		}
 	});
 }
 
@@ -813,15 +644,24 @@ void URuntimeAudioImporterLibrary::OnResult_Internal(UImportedSoundWave* SoundWa
 {
 	AsyncTask(ENamedThreads::GameThread, [this, SoundWaveRef, Status]()
 	{
-		if (OnResult.IsBound())
+		bool bBroadcasted = false;
+		const bool bSuccess = SoundWaveRef != nullptr;
+		
+		if( OnResultNative.IsBound() )
 		{
+			bBroadcasted = true;
+			OnResultNative.Broadcast(this, SoundWaveRef, Status);
+		}
+		
+		if( OnResult.IsBound() )
+		{
+			bBroadcasted = true;
 			OnResult.Broadcast(this, SoundWaveRef, Status);
 		}
-		else
+		
+		if( !bBroadcasted )
 		{
 			UE_LOG(LogRuntimeAudioImporter, Error, TEXT("You did not bind to the delegate to get the result of the import"));
 		}
-
-		RemoveFromRoot();
 	});
 }

--- a/Source/RuntimeAudioImporter/Private/RuntimeAudioImporterLibrary.cpp
+++ b/Source/RuntimeAudioImporter/Private/RuntimeAudioImporterLibrary.cpp
@@ -15,11 +15,6 @@
 #include "Misc/FileHelper.h"
 #include "Async/Async.h"
 
-#if ENGINE_MAJOR_VERSION < 5
-#include "AudioDevice.h"
-#include "AudioCompressionSettingsUtils.h"
-#endif
-
 URuntimeAudioImporterLibrary* URuntimeAudioImporterLibrary::CreateRuntimeAudioImporter()
 {
 	return NewObject<URuntimeAudioImporterLibrary>();
@@ -133,55 +128,6 @@ void URuntimeAudioImporterLibrary::ImportAudioFromRAWBuffer(TArray<uint8> RAWBuf
 
 	ImportAudioFromFloat32Buffer(reinterpret_cast<uint8*>(PCMData), PCMDataSize, SampleRate, NumOfChannels);
 }
-
-#if ENGINE_MAJOR_VERSION < 5
-FName GetPlatformSpecificFormat(const FName& Format)
-{
-	const FPlatformAudioCookOverrides* CompressionOverrides = FPlatformCompressionUtilities::GetCookOverrides();
-
-	// Platforms that require compression overrides get concatenated formats
-
-#if WITH_EDITOR
-
-	FName PlatformSpecificFormat;
-	if (CompressionOverrides)
-	{
-		FString HashedString = *Format.ToString();
-		FPlatformAudioCookOverrides::GetHashSuffix(CompressionOverrides, HashedString);
-		PlatformSpecificFormat = *HashedString;
-	}
-	else
-	{
-		PlatformSpecificFormat = Format;
-	}
-
-#else
-
-	// Cache the concatenated hash
-	
-	static FName PlatformSpecificFormat;
-	static FName CachedFormat;
-	if (!Format.IsEqual(CachedFormat))
-	{
-		if (CompressionOverrides)
-		{
-			FString HashedString = *Format.ToString();
-			FPlatformAudioCookOverrides::GetHashSuffix(CompressionOverrides, HashedString);
-			PlatformSpecificFormat = *HashedString;
-		}
-		else
-		{
-			PlatformSpecificFormat = Format;
-		}
-
-		CachedFormat = Format;
-	}
-
-#endif
-
-	return PlatformSpecificFormat;
-}
-#endif
 
 void URuntimeAudioImporterLibrary::ImportAudioFromPreImportedSound(UPreImportedSoundAsset* PreImportedSoundAssetRef)
 {

--- a/Source/RuntimeAudioImporter/Private/RuntimeAudioImporterLibrary.cpp
+++ b/Source/RuntimeAudioImporter/Private/RuntimeAudioImporterLibrary.cpp
@@ -311,7 +311,7 @@ bool URuntimeAudioImporterLibrary::ExportSoundWaveToBuffer(UImportedSoundWave* I
 
 void URuntimeAudioImporterLibrary::ImportAudioFromDecodedInfo(const FDecodedAudioStruct& DecodedAudioInfo)
 {
-	UImportedSoundWave* SoundWaveRef = NewObject<UImportedSoundWave>(UImportedSoundWave::StaticClass());
+	UImportedSoundWave* SoundWaveRef = CreateImportedSoundWave();
 
 	if (SoundWaveRef == nullptr)
 	{
@@ -568,6 +568,11 @@ bool URuntimeAudioImporterLibrary::EncodeAudioData(const FDecodedAudioStruct& De
 	}
 
 	return true;
+}
+
+UImportedSoundWave* URuntimeAudioImporterLibrary::CreateImportedSoundWave() const
+{
+	return NewObject<UImportedSoundWave>();
 }
 
 void URuntimeAudioImporterLibrary::OnProgress_Internal(int32 Percentage)

--- a/Source/RuntimeAudioImporter/Private/Transcoders/TranscodersIncludes.h
+++ b/Source/RuntimeAudioImporter/Private/Transcoders/TranscodersIncludes.h
@@ -14,22 +14,22 @@
 #define memset(Dest, Char, Count)	FMemory::Memset(Dest, Char, Count)
 
 #ifdef INCLUDE_MP3
-#include "dr_mp3.h"
+#include "ThirdParty/dr_mp3.h"
 #endif
 
 #ifdef INCLUDE_WAV
-#include "dr_wav.h"
+#include "ThirdParty/dr_wav.h"
 #endif
 
 #ifdef INCLUDE_FLAC
-#include "dr_flac.h"
+#include "ThirdParty/dr_flac.h"
 #endif
 
 #ifdef INCLUDE_VORBIS
 #if PLATFORM_SUPPORTS_VORBIS_CODEC
 #include "vorbis/vorbisenc.h"
 #endif
-#include "stb_vorbis.c"
+#include "ThirdParty/stb_vorbis.c"
 #endif
 
 #ifdef INCLUDE_OPUS

--- a/Source/RuntimeAudioImporter/Public/RuntimeAudioCompressor.h
+++ b/Source/RuntimeAudioImporter/Public/RuntimeAudioCompressor.h
@@ -31,13 +31,12 @@ public:
 	 * @return The RuntimeAudioCompressor object. Bind to it's OnResult delegate
 	 */
 	UFUNCTION(BlueprintCallable, meta = (Keywords = "Create, Audio, Runtime, Compress"), Category = "Runtime Audio Importer")
-	static URuntimeAudioCompressor* Create();
+	static URuntimeAudioCompressor* CreateRuntimeAudioCompressor();
 
 	/**
 	 * Compress ImportedSoundWave to regular SoundWave. This greatly reduces the size of the audio data in memory and can improve performance
 	 *
 	 * @param ImportedSoundWaveRef Reference to the imported sound wave
-	 * @param OnCompressedResult Delegate broadcast the compressed sound wave
 	 * @param CompressedSoundWaveInfo Basic information for filling a sound wave (partially taken from the standard Sound Wave asset)
 	 * @param Quality The quality of the encoded audio data. From 0 to 100
 	 * @param bFillCompressedBuffer Whether to fill the compressed buffer. It is supposed to be true to reduce memory

--- a/Source/RuntimeAudioImporter/Public/RuntimeAudioCompressor.h
+++ b/Source/RuntimeAudioImporter/Public/RuntimeAudioCompressor.h
@@ -1,0 +1,59 @@
+// Georgy Treshchev 2022.
+
+#pragma once
+
+#include "ImportedSoundWave.h"
+#include "RuntimeAudioImporterTypes.h"
+#include "RuntimeAudioCompressor.generated.h"
+
+/** Delegate broadcast the compressed sound wave */
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnSoundWaveCompressedResult, bool, bSuccess, USoundWave*, SoundWaveRef);
+DECLARE_MULTICAST_DELEGATE_TwoParams(FOnSoundWaveCompressedResultNative, bool bSuccess, USoundWave* SoundWaveRef);
+
+/**
+ * Runtime Audio Compressor
+ * Utilized for sound compression
+ */
+UCLASS(BlueprintType, Category = "Runtime Audio Importer")
+class RUNTIMEAUDIOIMPORTER_API URuntimeAudioCompressor : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	//** Bind to know when audio compression is complete (even if it fails) */
+	UPROPERTY(BlueprintAssignable, Category = "Runtime Audio Importer|Delegates")
+	FOnSoundWaveCompressedResult OnResult;
+	FOnSoundWaveCompressedResultNative OnResultNative;
+
+	/**
+	 * Instantiates a RuntimeAudioCompressor object
+	 *
+	 * @return The RuntimeAudioCompressor object. Bind to it's OnResult delegate
+	 */
+	UFUNCTION(BlueprintCallable, meta = (Keywords = "Create, Audio, Runtime, Compress"), Category = "Runtime Audio Importer")
+	static URuntimeAudioCompressor* Create();
+
+	/**
+	 * Compress ImportedSoundWave to regular SoundWave. This greatly reduces the size of the audio data in memory and can improve performance
+	 *
+	 * @param ImportedSoundWaveRef Reference to the imported sound wave
+	 * @param OnCompressedResult Delegate broadcast the compressed sound wave
+	 * @param CompressedSoundWaveInfo Basic information for filling a sound wave (partially taken from the standard Sound Wave asset)
+	 * @param Quality The quality of the encoded audio data. From 0 to 100
+	 * @param bFillCompressedBuffer Whether to fill the compressed buffer. It is supposed to be true to reduce memory
+	 * @param bFillPCMBuffer Whether to fill PCM buffer. Mainly used for in-engine previews. It is recommended not to enable to save memory
+	 * @param bFillRAWWaveBuffer Whether to fill RAW Wave buffer. It is recommended not to enable to save memory
+	 *
+	 * @note Some unique features will be missing, such as the "OnGeneratePCMData" delegate. But at the same time, you do not need to manually rewind the sound wave through "RewindPlaybackTime", but use traditional methods
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Runtime Audio Importer|Utilities")
+	void CompressSoundWave(UImportedSoundWave* ImportedSoundWaveRef, FCompressedSoundWaveInfo CompressedSoundWaveInfo, uint8 Quality, bool bFillCompressedBuffer, bool bFillPCMBuffer, bool bFillRAWWaveBuffer);
+
+private:
+	/**
+	 * Audio compression finished callback
+	 * 
+	 * @param SoundWaveRef Reference to the compressed sound wave
+	 */
+	void BroadcastResult(USoundWave* SoundWaveRef);
+};

--- a/Source/RuntimeAudioImporter/Public/RuntimeAudioImporterLibrary.h
+++ b/Source/RuntimeAudioImporter/Public/RuntimeAudioImporterLibrary.h
@@ -230,6 +230,9 @@ public:
 	static void FillPCMData(UImportedSoundWave* SoundWaveRef, const FDecodedAudioStruct& DecodedAudioInfo);
 
 protected:
+	/** Creates a new instance of the ImportedSoundWave class to use */
+	virtual UImportedSoundWave* CreateImportedSoundWave();
+
 	/**
 	 * Audio transcoding progress callback
 	 * 

--- a/Source/RuntimeAudioImporter/Public/RuntimeAudioImporterLibrary.h
+++ b/Source/RuntimeAudioImporter/Public/RuntimeAudioImporterLibrary.h
@@ -231,7 +231,7 @@ public:
 
 protected:
 	/** Creates a new instance of the ImportedSoundWave class to use */
-	virtual UImportedSoundWave* CreateImportedSoundWave();
+	virtual UImportedSoundWave* CreateImportedSoundWave() const;
 
 	/**
 	 * Audio transcoding progress callback

--- a/Source/RuntimeAudioImporter/Public/RuntimeAudioImporterLibrary.h
+++ b/Source/RuntimeAudioImporter/Public/RuntimeAudioImporterLibrary.h
@@ -8,19 +8,18 @@
 
 /** Delegate broadcast to get the audio importer progress */
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnAudioImporterProgress, const int32, Percentage);
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnAudioImporterProgressNative, const int32 Percentage);
 
 /** Delegate broadcast to get the audio importer result */
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FOnAudioImporterResult, class URuntimeAudioImporterLibrary*, RuntimeAudioImporterObjectRef, UImportedSoundWave*, SoundWaveRef, ETranscodingStatus, Status);
-
-/** Delegate broadcast the compressed sound wave */
-DECLARE_DYNAMIC_DELEGATE_TwoParams(FOnSoundWaveCompressedResult, bool, bSuccess, USoundWave*, SoundWaveRef);
+DECLARE_MULTICAST_DELEGATE_ThreeParams(FOnAudioImporterResultNative, class URuntimeAudioImporterLibrary* RuntimeAudioImporterObjectRef, UImportedSoundWave* SoundWaveRef, ETranscodingStatus Status);
 
 /** Forward declaration of the UPreImportedSoundAsset class */
 class UPreImportedSoundAsset;
 
 /**
  * Runtime Audio Importer library
- * Various functions related to transcoding audio data, such as importing audio files, manually encoding / decoding audio data, sound wave compression and more
+ * Various functions related to transcoding audio data, such as importing audio files, manually encoding / decoding audio data and more
  */
 UCLASS(BlueprintType, Category = "Runtime Audio Importer")
 class RUNTIMEAUDIOIMPORTER_API URuntimeAudioImporterLibrary : public UObject
@@ -31,10 +30,12 @@ public:
 	/** Bind to know when audio import is on progress */
 	UPROPERTY(BlueprintAssignable, Category = "Runtime Audio Importer|Delegates")
 	FOnAudioImporterProgress OnProgress;
+	FOnAudioImporterProgressNative OnProgressNative;
 
 	/** Bind to know when audio import is complete (even if it fails) */
 	UPROPERTY(BlueprintAssignable, Category = "Runtime Audio Importer|Delegates")
 	FOnAudioImporterResult OnResult;
+	FOnAudioImporterResultNative OnResultNative;
 
 	/**
 	 * Instantiates a RuntimeAudioImporter object
@@ -91,22 +92,6 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, meta = (DisplayName = "Import Audio From RAW Buffer"), Category = "Runtime Audio Importer|Import")
 	void ImportAudioFromRAWBuffer(TArray<uint8> RAWBuffer, ERAWAudioFormat Format, int32 SampleRate = 44100, int32 NumOfChannels = 1);
-
-	/**
-	 * Compress ImportedSoundWave to regular SoundWave. This greatly reduces the size of the audio data in memory and can improve performance
-	 *
-	 * @param ImportedSoundWaveRef Reference to the imported sound wave
-	 * @param OnCompressedResult Delegate broadcast the compressed sound wave
-	 * @param CompressedSoundWaveInfo Basic information for filling a sound wave (partially taken from the standard Sound Wave asset)
-	 * @param Quality The quality of the encoded audio data. From 0 to 100
-	 * @param bFillCompressedBuffer Whether to fill the compressed buffer. It is supposed to be true to reduce memory
-	 * @param bFillPCMBuffer Whether to fill PCM buffer. Mainly used for in-engine previews. It is recommended not to enable to save memory
-	 * @param bFillRAWWaveBuffer Whether to fill RAW Wave buffer. It is recommended not to enable to save memory
-	 *
-	 * @note Some unique features will be missing, such as the "OnGeneratePCMData" delegate. But at the same time, you do not need to manually rewind the sound wave through "RewindPlaybackTime", but use traditional methods
-	 */
-	UFUNCTION(BlueprintCallable, Category = "Runtime Audio Importer|Utilities")
-	void CompressSoundWave(UImportedSoundWave* ImportedSoundWaveRef, FOnSoundWaveCompressedResult OnCompressedResult, FCompressedSoundWaveInfo CompressedSoundWaveInfo, uint8 Quality, bool bFillCompressedBuffer, bool bFillPCMBuffer, bool bFillRAWWaveBuffer);
 
 	/**
 	 * Transcoding one RAW Data format to another
@@ -194,8 +179,6 @@ public:
 	 */
 	static bool EncodeAudioData(const FDecodedAudioStruct& DecodedAudioInfo, FEncodedAudioStruct& EncodedAudioInfo, uint8 Quality);
 
-private:
-
 	/**
 	 * Determine audio format based on audio data
 	 *
@@ -228,7 +211,7 @@ private:
 	 * @param DecodedAudioInfo Decoded audio data
 	 * @return Whether the defining was successful or not
 	 */
-	bool DefineSoundWave(UImportedSoundWave* SoundWaveRef, const FDecodedAudioStruct& DecodedAudioInfo);
+	virtual void DefineSoundWave(UImportedSoundWave* SoundWaveRef, const FDecodedAudioStruct& DecodedAudioInfo);
 
 	/**
 	 * Fill SoundWave basic information (e.g. duration, number of channels, etc)
@@ -246,6 +229,7 @@ private:
 	 */
 	static void FillPCMData(UImportedSoundWave* SoundWaveRef, const FDecodedAudioStruct& DecodedAudioInfo);
 
+protected:
 	/**
 	 * Audio transcoding progress callback
 	 * 

--- a/Source/RuntimeAudioImporter/RuntimeAudioImporter.Build.cs
+++ b/Source/RuntimeAudioImporter/RuntimeAudioImporter.Build.cs
@@ -6,11 +6,6 @@ using UnrealBuildTool;
 
 public class RuntimeAudioImporter : ModuleRules
 {
-	private string ThirdPartyPath
-	{
-		get { return Path.GetFullPath(Path.Combine(ModuleDirectory, "../ThirdParty/")); }
-	}
-
 	public RuntimeAudioImporter(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
@@ -29,8 +24,6 @@ public class RuntimeAudioImporter : ModuleRules
 				"DR_FLAC_IMPLEMENTATION=1"
 			}
 		);
-
-		PrivateIncludePaths.Add(ThirdPartyPath);
 
 		PrivateDependencyModuleNames.AddRange(
 			new string[]


### PR DESCRIPTION
Main feature of the PR is having compression as its own class. There's also the following:
- Added Native delegates for using the Plugin from C++
- Changed function signature to return void when it always just returned true
- Made DefineSoundWave virtual so that the class can be inherited from and extended without modifying the core plugin code
- Made static functions public again for use in extending the plugin without creating manual maintenance when the plugin is updated
- Fixed ThirdParty includes

Apart from adding a new function to the compression logic for result handling the code is the same