### PR TITLE
Fixed runtime audio compression

### DIFF
--- a/Source/RuntimeAudioImporter/Public/RuntimeAudioCompressor.h
+++ b/Source/RuntimeAudioImporter/Public/RuntimeAudioCompressor.h
@@ -50,7 +50,7 @@ public:
 	 * @note Some unique features will be missing, such as the "OnGeneratePCMData" delegate. But at the same time, you do not need to manually rewind the sound wave through "RewindPlaybackTime", but use traditional methods
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Runtime Audio Importer|Utilities")
-	void CompressSoundWave(UImportedSoundWave* ImportedSoundWaveRef, FCompressedSoundWaveInfo CompressedSoundWaveInfo, uint8 Quality, bool bFillCompressedBuffer, bool bFillPCMBuffer, bool bFillRAWWaveBuffer);
+	void CompressSoundWave(UImportedSoundWave* ImportedSoundWaveRef, FCompressedSoundWaveInfo CompressedSoundWaveInfo, uint8 Quality, /*bool bFillCompressedBuffer,*/ bool bFillPCMBuffer, bool bFillRAWWaveBuffer);
 
 private:
 	/**


### PR DESCRIPTION
Unfortunately, compressed audio has to be axed for now; I just don't know where to put a decoder, to make it function (and avoid the exception).

Using `EDecompressionType::DTYPE_Setup;` and filling the raw buffer works in editor, but not in a runtime build.