### PR TITLE
Compatibility with Windows.h header

### DIFF
--- a/Source/RuntimeAudioImporter/Public/Codecs/RAW_RuntimeCodec.h
+++ b/Source/RuntimeAudioImporter/Public/Codecs/RAW_RuntimeCodec.h
@@ -25,37 +25,37 @@ public:
 		// Signed 8-bit integer
 		if (std::is_same<IntegralType, int8>::value)
 		{
-			return TTuple<long long, long long>(std::numeric_limits<int8>::min(), std::numeric_limits<int8>::max());
+			return TTuple<long long, long long>((std::numeric_limits<int8>::min)(), (std::numeric_limits<int8>::max)());
 		}
 
 		// Unsigned 8-bit integer
 		if (std::is_same<IntegralType, uint8>::value)
 		{
-			return TTuple<long long, long long>(std::numeric_limits<uint8>::min(), std::numeric_limits<uint8>::max());
+			return TTuple<long long, long long>((std::numeric_limits<uint8>::min)(), (std::numeric_limits<uint8>::max)());
 		}
 
 		// Signed 16-bit integer
 		if (std::is_same<IntegralType, int16>::value)
 		{
-			return TTuple<long long, long long>(std::numeric_limits<int16>::min(), std::numeric_limits<int16>::max());
+			return TTuple<long long, long long>((std::numeric_limits<int16>::min)(), (std::numeric_limits<int16>::max)());
 		}
 
 		// Unsigned 16-bit integer
 		if (std::is_same<IntegralType, uint16>::value)
 		{
-			return TTuple<long long, long long>(std::numeric_limits<uint16>::min(), std::numeric_limits<uint16>::max());
+			return TTuple<long long, long long>((std::numeric_limits<uint16>::min)(), (std::numeric_limits<uint16>::max)());
 		}
 
 		// Signed 32-bit integer
 		if (std::is_same<IntegralType, int32>::value)
 		{
-			return TTuple<long long, long long>(std::numeric_limits<int32>::min(), std::numeric_limits<int32>::max());
+			return TTuple<long long, long long>((std::numeric_limits<int32>::min)(), (std::numeric_limits<int32>::max)());
 		}
 
 		// Unsigned 32-bit integer
 		if (std::is_same<IntegralType, uint32>::value)
 		{
-			return TTuple<long long, long long>(std::numeric_limits<uint32>::min(), std::numeric_limits<uint32>::max());
+			return TTuple<long long, long long>((std::numeric_limits<uint32>::min)(), (std::numeric_limits<uint32>::max)());
 		}
 
 		// Floating point 32-bit


### PR DESCRIPTION
I changed all the calls to std::numeric_limits<int8>::min() and std::numeric_limits<int8>::max() in the static TTuple, in RAW_RuntimeCodec.h, by wrapping the full name of each min/max in parenthesis.
eg:
std::numeric_limits<int8>::min() changed to (std::numeric_limits<int8>::min)()

Without that change, min and max are mistaken with macros defined in the windows header Windows.h, which makes the plugin impossible to compile while using Windows.h.