### PR TITLE
Update Plugin config

### DIFF
--- a/RuntimeAudioImporter.uplugin
+++ b/RuntimeAudioImporter.uplugin
@@ -10,10 +10,10 @@
   "DocsURL": "https://docs.georgy.dev/runtime-audio-importer/overview",
   "MarketplaceURL": "com.epicgames.launcher://ue/marketplace/product/81fd278e318e4235a028d3fdf46bf036",
   "SupportURL": "https://georgy.dev/",
-  "CanContainContent": true,
+  "CanContainContent": false,
   "IsBetaVersion": false,
   "IsExperimentalVersion": false,
-  "Installed": true,
+  "Installed": false,
   "Modules": [
     {
       "Name": "RuntimeAudioImporter",


### PR DESCRIPTION
- `Installed` Represents if the plugin has been installed to the engine folder. This gets automatically set to `true` for plugins downloaded from the marketplace/fab. But should be `false` by default.

- `Can Contain Content` should only be true when the plugin has content assets. When true UE mounts a content folder in the `Plugins` folder. This plugin has no content, so this should be false to not clutter the Plugin content folder.