### PR TITLE
Update ImportedSoundWave.cpp

### DIFF
--- a/Source/RuntimeAudioImporter/Private/Sound/ImportedSoundWave.cpp
+++ b/Source/RuntimeAudioImporter/Private/Sound/ImportedSoundWave.cpp
@@ -301,12 +301,6 @@ void UImportedSoundWave::Parse(FAudioDevice* AudioDevice, const UPTRINT NodeWave
 {
 	FRAIScopeLock Lock(&*DataGuard);
 
-	if (ActiveSound.PlaybackTime == 0.f)
-	{
-		UE_LOG(LogRuntimeAudioImporter, Log, TEXT("The playback time for the sound wave '%s' will be set to '%f'"), *GetName(), ParseParams.StartTime);
-		RewindPlaybackTime_Internal(ParseParams.StartTime);
-	}
-
 #if UE_VERSION_OLDER_THAN(5, 0, 0)
 	// In UE 4.27 and older, the engine can't play a procedural sound wave if the playback time is not zero, so we have to set it to zero
 	const_cast<FSoundParseParameters&>(ParseParams).StartTime = 0;

--- a/Source/RuntimeAudioImporter/Private/Sound/ImportedSoundWave.cpp
+++ b/Source/RuntimeAudioImporter/Private/Sound/ImportedSoundWave.cpp
@@ -366,7 +366,13 @@ void UImportedSoundWave::Parse(FAudioDevice* AudioDevice, const UPTRINT NodeWave
 void UImportedSoundWave::PopulateAudioDataFromDecodedInfo(FDecodedAudioStruct&& DecodedAudioInfo)
 {
 	FRAIScopeLock Lock(&*DataGuard);
-
+	
+	if (ActiveSound.PlaybackTime == 0.f)
+	{
+		UE_LOG(LogRuntimeAudioImporter, Log, TEXT("The playback time for the sound wave '%s' will be set to '%f'"), *GetName(), ParseParams.StartTime);
+		RewindPlaybackTime_Internal(FMath::Max(.00001f, ParseParams.StartTime));
+	}
+	
 	// If the sound wave has not yet been filled in with audio data and the initial desired sample rate and the number of channels are set, resample and mix the channels
 	if (InitialDesiredSampleRate.IsSet() || InitialDesiredNumOfChannels.IsSet())
 	{


### PR DESCRIPTION
bugfix: PlaySound2D and SpawnSound2D replays from the beginning of the sound wave every frame; remove rewind to beginning in Parse function