### PR TITLE
Update ImportedSoundWave.cpp

### DIFF
--- a/Source/RuntimeAudioImporter/Private/Sound/ImportedSoundWave.cpp
+++ b/Source/RuntimeAudioImporter/Private/Sound/ImportedSoundWave.cpp
@@ -301,7 +301,7 @@ void UImportedSoundWave::Parse(FAudioDevice* AudioDevice, const UPTRINT NodeWave
 {
 	FRAIScopeLock Lock(&*DataGuard);
 
-	if (ActiveSound.PlaybackTime == 0.f)
+	if (ActiveSound.PlaybackTime == 0 && ActiveSound.PlaybackTime != ParseParams.StartTime)
 	{
 		UE_LOG(LogRuntimeAudioImporter, Log, TEXT("The playback time for the sound wave '%s' will be set to '%f'"), *GetName(), ParseParams.StartTime);
 		RewindPlaybackTime_Internal(ParseParams.StartTime);


### PR DESCRIPTION
bugfix: playing sounds with bIsUISound set to true and StartTime set to 0 while the game is paused causes audible glitch and rewinding to 0 every frame
This is a rework of #84